### PR TITLE
Remove dark mode styles and simplify light theme content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ const EngagementDetail = lazy(() =>
 )
 
 function RouteFallback() {
-  return <p className="py-4 text-gray-700 dark:text-gray-300">Loading...</p>
+  return <p className="py-4 text-gray-700">Loading...</p>
 }
 
 function ScrollToTop() {
@@ -59,11 +59,11 @@ function App() {
   return (
     <Router>
       <ScrollToTop />
-      <div className="min-h-screen w-full flex flex-col justify-center items-center bg-white dark:bg-neutral-900">
+      <div className="min-h-screen w-full flex flex-col justify-center items-center bg-white">
         <main className="w-full max-w-3xl px-4 sm:px-8 py-10 flex-1 flex flex-col">
           <ProfileCardWithRouteControl />
           <Routes>
-            <Route path="/" element={<><div className="border-b border-gray-200 dark:border-neutral-800 mb-10"></div><ProfileSummary /><div className="border-b border-gray-200 dark:border-neutral-800 mb-10"></div><ReadingSummary /><div className="border-b border-gray-200 dark:border-neutral-800 mb-10"></div><BlogSummary /><div className="border-b border-gray-200 dark:border-neutral-800 mb-10"></div><PublicEngagements /></>} />
+            <Route path="/" element={<><div className="border-b border-gray-200 mb-10"></div><ProfileSummary /><div className="border-b border-gray-200 mb-10"></div><ReadingSummary /><div className="border-b border-gray-200 mb-10"></div><BlogSummary /><div className="border-b border-gray-200 mb-10"></div><PublicEngagements /></>} />
             <Route path="/projects" element={<Suspense fallback={<RouteFallback />}><ProjectList /></Suspense>} />
             <Route path="/projects/:id" element={<Suspense fallback={<RouteFallback />}><ProjectRedirect /></Suspense>} />
             <Route path="/projects/:id/paper" element={<Suspense fallback={<RouteFallback />}><ProjectPaper /></Suspense>} />
@@ -76,7 +76,7 @@ function App() {
             <Route path="/engagements/:id" element={<Suspense fallback={<RouteFallback />}><EngagementDetail /></Suspense>} />
           </Routes>
         </main>
-        <footer className="w-full text-center text-gray-500 dark:text-gray-400 text-sm mt-16 border-t border-gray-100 dark:border-neutral-800 pt-6 pb-4">
+        <footer className="w-full text-center text-gray-500 text-sm mt-16 border-t border-gray-100 pt-6 pb-4">
           © {new Date().getFullYear()} Abhishek Sankar, inspired by <a href="https://aarushsah.com/" target="_blank" rel="noopener noreferrer" className="text-phthalo-green-500 hover:underline">aarushsah.com</a> 
         </footer>
       </div>

--- a/src/components/BlogPages.tsx
+++ b/src/components/BlogPages.tsx
@@ -20,7 +20,7 @@ const BLOG_COMPONENTS = {
 } as const;
 
 function PostFallback() {
-  return <p className="text-gray-700 dark:text-gray-300">Loading post...</p>;
+  return <p className="text-gray-700">Loading post...</p>;
 }
 
 export const BlogList = () => {
@@ -36,13 +36,13 @@ export const BlogList = () => {
           <div key={blog.id} className="mb-5">
           <div className="font-semibold flex items-start justify-between gap-2">
             <Link to={`/blogs/${blog.id}`} className="text-phthalo-green-500 min-w-0">{blog.title}</Link>
-            <span className="text-gray-500 dark:text-gray-400 font-normal text-sm shrink-0 text-right">
+            <span className="text-gray-500 font-normal text-sm shrink-0 text-right">
               <DateText date={blog.date} />
               <span className="hidden sm:inline"> • </span>
               <span className="block sm:inline">{blog.readTime}</span>
             </span>
           </div>
-          <div className="text-base text-gray-700 dark:text-gray-300">{blog.summary}</div>
+          <div className="text-base text-gray-700">{blog.summary}</div>
           <Link to={`/blogs/${blog.id}`} className="text-phthalo-green-500 text-sm">Read post</Link>
         </div>
       ))}
@@ -71,7 +71,7 @@ export const BlogDetail = () => {
           <BlogComponent />
         </Suspense>
       ) : (
-        <div className="text-xl text-gray-700 dark:text-gray-300 mb-6">{blog.content}</div>
+        <div className="text-xl text-gray-700 mb-6">{blog.content}</div>
       )}
     </section>
   );

--- a/src/components/BlogSummary.tsx
+++ b/src/components/BlogSummary.tsx
@@ -13,13 +13,13 @@ export const BlogSummary: React.FC = () => {
                 <div key={blog.id} className="mb-4">
                     <div className="font-semibold flex items-start justify-between gap-2">
                         <Link to={`/blogs/${blog.id}`} className="text-phthalo-green-500 min-w-0">{blog.title}</Link>
-                        <span className="text-gray-500 dark:text-gray-400 font-normal text-sm shrink-0 text-right">
+                        <span className="text-gray-500 font-normal text-sm shrink-0 text-right">
                             <DateText date={blog.date} />
                             <span className="hidden sm:inline"> • </span>
                             <span className="block sm:inline">{blog.readTime}</span>
                         </span>
                     </div>
-                    <div className="text-base text-gray-700 dark:text-gray-300">{blog.summary}</div>
+                    <div className="text-base text-gray-700">{blog.summary}</div>
                     <Link to={`/blogs/${blog.id}`} className="text-phthalo-green-500 text-sm">Read post</Link>
                 </div>
             ))}

--- a/src/components/EngagementPages.tsx
+++ b/src/components/EngagementPages.tsx
@@ -11,9 +11,9 @@ export const EngagementList = () => (
       <div className="mb-5" key={engagement.id}>
         <div className="font-semibold flex flex-col sm:flex-row sm:items-start sm:gap-2">
           <p>{engagement.title}</p>
-          <DateText date={engagement.date} className="text-gray-500 dark:text-gray-400 font-normal text-sm" />
+          <DateText date={engagement.date} className="text-gray-500 font-normal text-sm" />
         </div>
-        {engagement.description ? <div className="text-base text-gray-700 dark:text-gray-300">{engagement.description}</div> : null}
+        {engagement.description ? <div className="text-base text-gray-700">{engagement.description}</div> : null}
         {engagement.links && (
           <div className="text-sm mt-1">
             {engagement.links.map((link: { label: string; url: string }) => (
@@ -36,12 +36,12 @@ export const EngagementDetail = () => {
     <section className="max-w-3xl mx-auto">
       <Link to="/engagements" className="text-phthalo-green-500 hover:underline block mb-6">&larr; Engagements</Link>
       <h1 className="text-4xl font-bold mb-2">{engagement.title}</h1>
-      <p className="text-lg text-gray-500 dark:text-gray-400 mb-6">
+      <p className="text-lg text-gray-500 mb-6">
         <DateText date={engagement.date} />
       </p>
-      {engagement.description && <div className="text-xl text-gray-700 dark:text-gray-300 mb-6">{engagement.description}</div>}
+      {engagement.description && <div className="text-xl text-gray-700 mb-6">{engagement.description}</div>}
       {engagement.links && (
-        <div className="text-base text-gray-700 dark:text-gray-300 underline">
+        <div className="text-base text-gray-700 underline">
           {engagement.links.map((link, idx) => (
             <span key={link.url}>
               <a href={link.url} target="_blank" rel="noreferrer" className="text-phthalo-green-500">{link.label}</a>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -63,7 +63,7 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({ showDescription = true
             </div>
           </header>
         {showDescription && (
-          <div className="text-base text-gray-700 dark:text-gray-300 mb-6">
+          <div className="text-base text-gray-700 mb-6">
             I'm a graduate student at <a href="https://msaii.cs.cmu.edu/directory/students/current/s" target="_blank" rel="noopener noreferrer" className="text-phthalo-green-500 hover:underline">Carnegie Mellon University</a> studying Artificial Intelligence.
             I'm interested in efforts toward systems that make English the main programming language.
             

--- a/src/components/ProfileSummary.tsx
+++ b/src/components/ProfileSummary.tsx
@@ -14,9 +14,9 @@ export const ProfileSummary: React.FC = () => {
         <div className="mb-5" key={project.id}>
           <div className="font-semibold flex flex-col sm:flex-row sm:items-start sm:gap-2">
             <p>{project.title}</p>
-            <DateText date={project.date} className="text-gray-500 dark:text-gray-400 font-normal text-sm" />
+            <DateText date={project.date} className="text-gray-500 font-normal text-sm" />
           </div>
-          <div className="text-base text-gray-700 dark:text-gray-300">{project.description}</div>
+          <div className="text-base text-gray-700">{project.description}</div>
           <div className="text-sm mt-1">
             {project.links.map((link: { label: string; url: string }) => (
               link.url.startsWith("/") ? (

--- a/src/components/ProjectPages.tsx
+++ b/src/components/ProjectPages.tsx
@@ -19,9 +19,9 @@ export const ProjectList = () => {
             <Link to={`/projects/${project.id}/paper`} className="text-phthalo-green-500 hover:underline">
               {project.title}
             </Link>
-            <DateText date={project.date} className="text-gray-500 dark:text-gray-400 font-normal text-sm" />
+            <DateText date={project.date} className="text-gray-500 font-normal text-sm" />
           </div>
-          <div className="text-base text-gray-700 dark:text-gray-300">{project.description}</div>
+          <div className="text-base text-gray-700">{project.description}</div>
           <div className="text-sm mt-1">
             {project.links.map((link: { label: string; url: string }) => (
               link.url.startsWith("/") ? (
@@ -67,8 +67,8 @@ export const ProjectDetail = () => {
       <p className="text-lg text-gray-500 mb-6">
         <DateText date={project.date} />
       </p>
-      <div className="text-xl text-gray-700 dark:text-gray-300 mb-6">{project.description}</div>
-      <div className="text-base text-gray-700 dark:text-gray-300 underline">
+      <div className="text-xl text-gray-700 mb-6">{project.description}</div>
+      <div className="text-base text-gray-700 underline">
         {project.links.map((link, idx) => (
           <span key={link.url}>
             {link.url.startsWith("/") ? (

--- a/src/components/ProjectPaper.tsx
+++ b/src/components/ProjectPaper.tsx
@@ -111,7 +111,7 @@ export const ProjectPaper = () => {
           &larr; Projects
         </Link>
         <h1 className="text-3xl font-bold mb-4">{project.title}</h1>
-        <p className="text-gray-700 dark:text-gray-300">Paper view is not available for this project yet.</p>
+        <p className="text-gray-700">Paper view is not available for this project yet.</p>
       </section>
     );
   }
@@ -124,18 +124,18 @@ export const ProjectPaper = () => {
 
       <div className="mb-6">
         <h1 className="text-3xl font-bold mb-2">{project.title}</h1>
-        <div className="text-sm text-gray-500 dark:text-gray-400">
+        <div className="text-sm text-gray-500">
           <a href={paperMeta.originalPdfPath} className="text-phthalo-green-500" target="_blank" rel="noreferrer">
             Original PDF
           </a>
         </div>
       </div>
 
-      {isLoading ? <p className="text-gray-700 dark:text-gray-300">Loading paper...</p> : null}
-      {error ? <p className="text-red-600 dark:text-red-400">{error}</p> : null}
+      {isLoading ? <p className="text-gray-700">Loading paper...</p> : null}
+      {error ? <p className="text-red-600">{error}</p> : null}
 
       {!isLoading && !error ? (
-        <article className="paper-content text-gray-800 dark:text-gray-200">
+        <article className="paper-content text-gray-800">
           <ReactMarkdown
             remarkPlugins={[remarkGfm, remarkMath]}
             rehypePlugins={[rehypeKatex]}

--- a/src/components/PublicEngagements.tsx
+++ b/src/components/PublicEngagements.tsx
@@ -14,9 +14,9 @@ export const PublicEngagements: React.FC = () => {
         <div className="mb-5" key={engagement.id}>
           <div className="font-semibold flex flex-col sm:flex-row sm:items-start sm:gap-2">
             <p>{engagement.title}</p>
-            <DateText date={engagement.date} className="text-gray-500 dark:text-gray-400 font-normal text-sm" />
+            <DateText date={engagement.date} className="text-gray-500 font-normal text-sm" />
           </div>
-          {engagement.description ? <div className="text-base text-gray-700 dark:text-gray-300">{engagement.description}</div> : null}
+          {engagement.description ? <div className="text-base text-gray-700">{engagement.description}</div> : null}
           {engagement.links && (
             <div className="text-sm mt-1">
               {engagement.links.map((link: { label: string; url: string }) => (

--- a/src/components/ReadingPages.tsx
+++ b/src/components/ReadingPages.tsx
@@ -23,7 +23,7 @@ function ScrollspyLine({
     >
       <span
         className={`block h-px w-full rounded-full transition-colors duration-200 ease-out ${
-          isActive ? "bg-phthalo-green-500" : "bg-neutral-300 dark:bg-neutral-600"
+          isActive ? "bg-phthalo-green-500" : "bg-neutral-300"
         }`}
       />
     </div>
@@ -96,7 +96,7 @@ export const ReadingList = () => {
             <div className="flex items-center gap-2">
               <div
                 className={`w-6 py-2 px-1.5 rounded-lg flex flex-col gap-0.5 items-center transition-colors duration-200 ${
-                  popoverOpen ? "bg-neutral-100 dark:bg-neutral-800" : ""
+                  popoverOpen ? "bg-neutral-100" : ""
                 }`}
               >
                 {readings.map((r) => (
@@ -110,15 +110,15 @@ export const ReadingList = () => {
               </div>
 
               {popoverOpen && (
-                <div className="w-max max-w-64 rounded-2xl border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 shadow-lg py-3 px-3 max-h-[60vh] overflow-y-auto">
+                <div className="w-max max-w-64 rounded-2xl border border-neutral-200 bg-white shadow-lg py-3 px-3 max-h-[60vh] overflow-y-auto">
                   {visible.map((r) => (
                     <button
                       key={r.id}
                       onClick={() => scrollTo(r.id)}
-                      className={`block w-full text-left py-2.5 px-3 text-sm transition-colors duration-200 rounded-xl !bg-transparent hover:!bg-neutral-100 dark:hover:!bg-neutral-800 !border-0 hover:!border-0 focus:!border-0 focus-visible:!border-0 !outline-none focus:!outline-none focus-visible:!outline-none !ring-0 focus:!ring-0 focus-visible:!ring-0 !shadow-none ${
+                      className={`block w-full text-left py-2.5 px-3 text-sm transition-colors duration-200 rounded-xl !bg-transparent hover:!bg-neutral-100 !border-0 hover:!border-0 focus:!border-0 focus-visible:!border-0 !outline-none focus:!outline-none focus-visible:!outline-none !ring-0 focus:!ring-0 focus-visible:!ring-0 !shadow-none ${
                         activeId === r.id
                           ? "text-phthalo-green-500 font-medium"
-                          : "text-neutral-600 dark:text-neutral-400"
+                          : "text-neutral-600"
                       }`}
                     >
                       {getPopoverLabel(r.title)}

--- a/src/components/ReadingSummary.tsx
+++ b/src/components/ReadingSummary.tsx
@@ -17,7 +17,7 @@ export const ReadingSummary: React.FC = () => {
     return (
         <section className="mb-12">
             <h2 className="text-lg sm:text-xl font-semibold mb-4 flex items-center gap-2">
-                Reading <Link to="/reading" className="text-emerald-800 dark:text-emerald-300 text-sm font-normal ml-1 cursor-pointer">View all →</Link>
+                Reading <Link to="/reading" className="text-emerald-800 text-sm font-normal ml-1 cursor-pointer">View all →</Link>
             </h2>
             <ul className="list-none space-y-3 m-0 p-0">
                 {latestItems.map((item) => (
@@ -26,7 +26,7 @@ export const ReadingSummary: React.FC = () => {
                             href={item.url} 
                             target="_blank" 
                             rel="noopener noreferrer"
-                            className="text-emerald-800 dark:text-emerald-300 hover:underline text-base"
+                            className="text-emerald-800 hover:underline text-base"
                         >
                             {item.title}
                         </a>

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
 }
 
 :root {
+  color-scheme: light;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -90,10 +91,6 @@ body {
   margin: 2rem 0;
 }
 
-.dark .paper-content hr {
-  border-top-color: rgb(82 82 82);
-}
-
 .paper-content table {
   width: 100%;
   border-collapse: collapse;
@@ -105,11 +102,6 @@ body {
   border-bottom: 1px solid rgb(212 212 212);
   padding: 0.45rem 0.35rem;
   text-align: left;
-}
-
-.dark .paper-content th,
-.dark .paper-content td {
-  border-bottom-color: rgb(82 82 82);
 }
 
 .paper-content .katex-display {
@@ -130,8 +122,4 @@ body {
 .paper-content p em {
   color: rgb(107 114 128);
   font-size: 0.94rem;
-}
-
-.dark .paper-content p em {
-  color: rgb(163 163 163);
 }


### PR DESCRIPTION
## Summary
- remove dark-mode Tailwind classes and `.dark` CSS overrides across the app shell and content pages
- force a light-only `color-scheme` and simplify related UI styling in reading, blog, project, and engagement views
- tighten reading summary markup and update project link labels to use a shorter `Read more` CTA

## Testing
- Not run (not requested)