### PR TITLE
Implement issue #17: Add dark mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { ProfileSummary } from './components/ProfileSummary'
 import { BlogSummary } from './components/BlogSummary'
 import { ReadingSummary } from './components/ReadingSummary'
 import { PublicEngagements } from './components/PublicEngagements'
+import { ThemeProvider, useTheme } from './ThemeContext'
 
 const ProjectList = lazy(() =>
   import('./components/ProjectPages').then((module) => ({ default: module.ProjectList })),
@@ -55,12 +56,42 @@ function ProfileCardWithRouteControl() {
   return <ProfileCard showDescription={!hideDescription} />;
 }
 
-function App() {
+function ThemeToggleButton() {
+  const { theme, toggleTheme } = useTheme()
+  const isDark = theme === 'dark'
+
+  return (
+    <button
+      className="theme-toggle"
+      data-testid="theme-toggle"
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      onClick={toggleTheme}
+    >
+      {isDark ? (
+        /* Sun icon for switching to light */
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z" />
+        </svg>
+      ) : (
+        /* Moon icon for switching to dark */
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path fillRule="evenodd" d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z" clipRule="evenodd" />
+        </svg>
+      )}
+    </button>
+  )
+}
+
+function AppShell() {
   return (
     <Router>
       <ScrollToTop />
       <div className="min-h-screen w-full flex flex-col justify-center items-center bg-white">
-        <main className="w-full max-w-3xl px-4 sm:px-8 py-10 flex-1 flex flex-col">
+        <div className="w-full max-w-3xl px-4 sm:px-8 pt-4 flex justify-end">
+          <ThemeToggleButton />
+        </div>
+        <main className="w-full max-w-3xl px-4 sm:px-8 py-6 flex-1 flex flex-col">
           <ProfileCardWithRouteControl />
           <Routes>
             <Route path="/" element={<><div className="border-b border-gray-200 mb-10"></div><ProfileSummary /><div className="border-b border-gray-200 mb-10"></div><ReadingSummary /><div className="border-b border-gray-200 mb-10"></div><BlogSummary /><div className="border-b border-gray-200 mb-10"></div><PublicEngagements /></>} />
@@ -81,6 +112,14 @@ function App() {
         </footer>
       </div>
     </Router>
+  )
+}
+
+function App() {
+  return (
+    <ThemeProvider>
+      <AppShell />
+    </ThemeProvider>
   )
 }
 

--- a/src/ThemeContext.tsx
+++ b/src/ThemeContext.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+type Theme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+})
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    // Respect stored preference first, then OS preference
+    const stored = localStorage.getItem('theme') as Theme | null
+    if (stored === 'dark' || stored === 'light') return stored
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  })
+
+  useEffect(() => {
+    const root = document.documentElement
+    root.setAttribute('data-theme', theme)
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'))
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useTheme() {
+  return useContext(ThemeContext)
+}

--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,35 @@
   --stagger-duration: 380ms;
   --stagger-step: 50ms;
   --stagger-easing: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Light mode design tokens */
+  --bg-primary: #ffffff;
+  --bg-secondary: #f9fafb;
+  --text-primary: #111827;
+  --text-secondary: #374151;
+  --text-muted: #6b7280;
+  --border-color: #e5e7eb;
+  --border-light: #f3f4f6;
+  --link-color: oklch(0.298 0.051 159.699);
+  --toggle-bg: #e5e7eb;
+  --toggle-hover-bg: #d1d5db;
+  --toggle-icon-color: #374151;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  /* Dark mode design tokens — WCAG AA compliant */
+  --bg-primary: #0f1117;
+  --bg-secondary: #1a1d27;
+  --text-primary: #f1f5f9;
+  --text-secondary: #cbd5e1;
+  --text-muted: #94a3b8;
+  --border-color: #2d3748;
+  --border-light: #1e2533;
+  --link-color: oklch(0.72 0.11 178);
+  --toggle-bg: #2d3748;
+  --toggle-hover-bg: #3d4f68;
+  --toggle-icon-color: #f1f5f9;
 }
 
 body {
@@ -26,6 +55,63 @@ body {
   min-width: 320px;
   min-height: 100vh;
   font-family: 'Newsreader', Georgia, serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* Global dark-mode overrides using CSS variables */
+[data-theme="dark"] a {
+  color: var(--link-color);
+}
+
+[data-theme="dark"] .text-gray-700 {
+  color: var(--text-secondary) !important;
+}
+
+[data-theme="dark"] .text-gray-500 {
+  color: var(--text-muted) !important;
+}
+
+[data-theme="dark"] .border-gray-200 {
+  border-color: var(--border-color) !important;
+}
+
+[data-theme="dark"] .border-gray-100 {
+  border-color: var(--border-light) !important;
+}
+
+[data-theme="dark"] .bg-white {
+  background-color: var(--bg-primary) !important;
+}
+
+[data-theme="dark"] .text-phthalo-green-500 {
+  color: var(--link-color) !important;
+}
+
+/* Theme toggle button */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  border: none;
+  background-color: var(--toggle-bg);
+  color: var(--toggle-icon-color);
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.theme-toggle:hover {
+  background-color: var(--toggle-hover-bg);
+}
+
+.theme-toggle svg {
+  width: 1rem;
+  height: 1rem;
 }
 
 .profile-avatar {


### PR DESCRIPTION
## Return Brief implementation

Closes #17
Issue: https://github.com/abhishek-sankar/abhisheksankar.com/issues/17

## Demo artifact

- [implementation-demo.mp4](https://github.com/abhishek-sankar/abhisheksankar.com/blob/return-brief/issue-17-add-dark-mode-20260426194618/outputs/implementation-demo.mp4)
- [implementation-plan.json](https://github.com/abhishek-sankar/abhisheksankar.com/blob/return-brief/issue-17-add-dark-mode-20260426194618/outputs/implementation-plan.json)
- [outputs/](https://github.com/abhishek-sankar/abhisheksankar.com/tree/return-brief/issue-17-add-dark-mode-20260426194618/outputs)

## Acceptance criteria

- The implementation addresses GitHub issue #17.
- The change is visible in the recorded app demo.
- The after demo visibly activates and records the dark-mode state, not the default light state.
- The app still renders meaningful content at APP_BASE_URL.
- The draft PR includes the implementation demo artifact.

## Verification

- `npm run lint`
- `npm run build`